### PR TITLE
Implement `roku_dev_server_rekey` Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Fastlane plugin for Roku app automation. All actions require a Roku dev server o
 
 ### Available actions
 * [`roku_dev_server_check`](#action-roku_dev_server_check) : Checks Roku dev server
+* [`roku_dev_server_rekey`](#action-roku_dev_server_rekey) : Rekeys the dev server to the provided signed package
 * [`roku_app_install`](#action-roku_app_install) : Installs the app as a dev channel on a Roku target device
 * [`roku_app_uninstall`](#action-roku_app_uninstall) : Uninstalls any apps/dev channels on a Roku target device
 * [`roku_app_package`](#action-roku_app_package) : Creates Roku package from application sources
@@ -30,6 +31,20 @@ Fastlane plugin for Roku app automation. All actions require a Roku dev server o
 Key  | Environment Variable Equivalent | Description | Required?
 ------------- | ------------- | ------------- | -------------
 `dev_target`  | `ROKUAPPUTIL_DEV_TARGET` | The IP of the Roku dev target | YES
+
+#### Action: `roku_dev_server_rekey`
+
+##### Description: Rekeys the dev server to the provided signed package
+
+##### Parameters:
+
+Key  | Environment Variable Equivalent | Description | Required?
+------------- | ------------- | ------------- | -------------
+`dev_target`  | `ROKUAPPUTIL_DEV_TARGET` | The IP of the Roku dev target | YES
+`dev_user`    | `ROKUAPPUTIL_DEV_USER`   | Roku development username | NO - Default value: `rokudev`
+`dev_pass`    | `ROKUAPPUTIL_DEV_PASS`   | Roku development password | YES
+`sign_key`    | `ROKUAPPUTIL_SIGN_KEY`   | Roku signing key | YES
+`app_path`    | `ROKUAPPUTIL_APP_PATH`   | Roku signed application file path | YES
 
 #### Action: `roku_app_install`
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,14 @@ lane :test do
     dev_target: "192.168.87.201" # or set environment variable ROKUAPPUTIL_DEV_TARGET
   )
 
+  roku_dev_server_rekey(
+    dev_target: "192.168.87.201",   # or set environment variable ROKUAPPUTIL_DEV_TARGET
+    dev_user: "rokudev",            # or set environment variable ROKUAPPUTIL_DEV_USER
+    dev_pass: "pass",               # or set environment variable ROKUAPPUTIL_DEV_PASS
+    sign_key: "secret",             # or set environment variable ROKUAPPUTIL_SIGN_KEY
+    app_path: "signed.pkg"          # or set environment variable ROKUAPPUTIL_APP_PATH
+  )
+
   roku_app_install(
     dev_target: "192.168.87.201",  # or set environment variable ROKUAPPUTIL_DEV_TARGET
     dev_user: "rokudev",           # or set environment variable ROKUAPPUTIL_DEV_USER

--- a/lib/fastlane/plugin/roku_app_util/actions/roku_dev_server_rekey.rb
+++ b/lib/fastlane/plugin/roku_app_util/actions/roku_dev_server_rekey.rb
@@ -1,0 +1,78 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/roku_app_util_helper'
+
+module Fastlane
+  module Actions
+    class RokuDevServerRekeyAction < Action
+      def self.run(params)
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          title: 'Summary for roku_dev_server_rekey',
+          mask_keys: [:dev_pass, :sign_key]
+        )
+
+        Helper::RokuAppUtilHelper.roku_app_rekey(params)
+
+        UI.success('Roku dev server rekeyed')
+      end
+
+      def self.description
+        'Rekeys Roku dev server'
+      end
+
+      # For each option, optional is set to true to prevent forcing Fastlane to be interactive and prompting for input
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :dev_target,
+            env_name: 'ROKUAPPUTIL_DEV_TARGET',
+            description: 'IP address of the Roku development device',
+            optional: true,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :dev_user,
+            env_name: 'ROKUAPPUTIL_DEV_USER',
+            description: 'Roku development username',
+            optional: true,
+            type: String,
+            default_value: 'rokudev'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :dev_pass,
+            env_name: 'ROKUAPPUTIL_DEV_PASS',
+            description: 'Roku development password',
+            optional: true,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :app_path,
+            env_name: 'ROKUAPPUTIL_APP_PATH',
+            description: 'Roku signed application file path',
+            optional: true,
+            type: String,
+            verify_block: proc do |value|
+              UI.user_error!('Could not find ZIP file') unless File.exist?(value)
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :sign_key,
+            env_name: 'ROKUAPPUTIL_SIGN_KEY',
+            description: 'Roku signing key',
+            optional: true,
+            type: String
+          ),
+        ]
+      end
+
+      def self.authors
+        ['Blair Replogle']
+      end
+
+      def self.is_supported?(platform)
+        [:roku].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
+++ b/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
@@ -208,8 +208,6 @@ module Fastlane
         unless result.include?("Success")
           UI.shell_error!("Error from Roku: #{result}")
         end
-
-        UI.success("Roku device rekeyed")
       end
 
 

--- a/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
+++ b/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
@@ -171,6 +171,48 @@ module Fastlane
         return File.expand_path(output_package_file)
       end
 
+      def self.roku_app_rekey(params)
+        validate_params(params, [:dev_target, :dev_user, :dev_pass, :sign_key, :app_path])
+
+        target = params[:dev_target]
+        user = params[:dev_user]
+        pass = params[:dev_pass]
+        sign_key = params[:sign_key]
+        app_path = params[:app_path]
+        user_pass = "#{user}:#{pass}"
+        current_time = DateTime.now.strftime('%Q')
+
+        cmd = ['curl']
+        cmd << "--user #{user_pass}"
+        cmd << "--digest"
+        cmd << "--silent"
+        cmd << "show-error"
+        cmd << "-F mysubmit=Rekey"
+        cmd << "-F passwd=#{sign_key}"
+        cmd << "-F archive=@#{app_path}"
+        cmd << "-F pkg_time=#{current_time}"
+        cmd << "http://#{target}/plugin_inspect"
+        cmd = cmd.join(' ')
+
+        response = `#{cmd}`
+
+        # Check exit code
+        if $?.exitstatus != 0
+          UI.shell_error!("Curl exit code #{$?.exitstatus}. See URL for meaning: https://everything.curl.dev/usingcurl/returns#available-exit-codes")
+        end
+
+        parsed_responses = validate_response_match(response, %r{<font color="red">(.*?)</font>}m)
+        result = parsed_responses[0]
+
+        # Dev server installation output will display 'Success' if app is packaged successfully
+        unless result.include?("Success")
+          UI.shell_error!("Error from Roku: #{result}")
+        end
+
+        UI.success("Roku device rekeyed")
+      end
+
+
       # A helper method to check if all the necessary parameters are set
       # params: An array containing all the parameters to check
       # keys: An array of keys to use in params


### PR DESCRIPTION
## Summary
Adds `roku_dev_server_rekey` action to be able to "rekey" a roku device to a specific channel / application.

## Documentation
`roku_dev_server_rekey`

Key  | Environment Variable Equivalent | Description | Required?
------------- | ------------- | ------------- | -------------
`dev_target`  | `ROKUAPPUTIL_DEV_TARGET` | The IP of the Roku dev target | YES
`dev_user`    | `ROKUAPPUTIL_DEV_USER`   | Roku development username | NO - Default value: `rokudev`
`dev_pass`    | `ROKUAPPUTIL_DEV_PASS`   | Roku development password | YES
`sign_key`    | `ROKUAPPUTIL_SIGN_KEY`   | Roku signing key | YES
`app_path`    | `ROKUAPPUTIL_APP_PATH`   | Roku signed application file path | YES

## Example
```
roku_dev_server_rekey(
    dev_target: "192.168.87.201",   # or set environment variable ROKUAPPUTIL_DEV_TARGET
    dev_user: "rokudev",            # or set environment variable ROKUAPPUTIL_DEV_USER
    dev_pass: "pass",               # or set environment variable ROKUAPPUTIL_DEV_PASS
    sign_key: "secret",             # or set environment variable ROKUAPPUTIL_SIGN_KEY
    app_path: "signed.pkg"          # or set environment variable ROKUAPPUTIL_APP_PATH
)
```

## Screenshots
![image](https://user-images.githubusercontent.com/2431082/177589687-c0fe358d-791b-4a78-a952-b70f91c52433.png)
